### PR TITLE
Added Icosahedron and Icosahedron Test

### DIFF
--- a/src/main/java/eu/mihosoft/vrl/v3d/Icosahedron.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Icosahedron.java
@@ -1,0 +1,142 @@
+/**
+ * Icosahedron.java
+ */
+package eu.mihosoft.vrl.v3d;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.mihosoft.vrl.v3d.ext.quickhull3d.HullUtil;
+import eu.mihosoft.vrl.v3d.parametrics.LengthParameter;
+import eu.mihosoft.vrl.v3d.parametrics.Parameter;
+
+public class Icosahedron extends Primitive {
+
+    /**
+     * Center of this icosahedron.
+     */
+    private Vector3d center;
+    /**
+     * Icosahedron circumscribed radius.
+     */
+    private double radius;
+
+    /** The centered. */
+    private boolean centered = true;
+
+    /** The properties. */
+    private final PropertyStorage properties = new PropertyStorage();
+    /**
+     * Constructor. Creates a new icosahedron with center {@code [0,0,0]} and
+     * dimensions {@code [1,1,1]}.
+     */
+    public Icosahedron() {
+        center = new Vector3d(0, 0, 0);
+        radius = 1;
+    }
+
+    /**
+     * Constructor. Creates a new icosahedron with center {@code [0,0,0]} and
+     * radius {@code size}.
+     *
+     * @param size size
+     */
+    public Icosahedron(double size) {
+        center = new Vector3d(0, 0, 0);
+        radius = size;
+    }
+
+    /**
+     * Constructor. Creates a new icosahedron with the specified center and
+     * radius.
+     *
+     * @param center center of the icosahedron
+     * @param circumradius of the icosahedron
+     */
+    public Icosahedron(Vector3d center, double size) {
+        this.center = center;
+        this.radius = size;
+    }
+    
+    /* (non-Javadoc)
+     * @see eu.mihosoft.vrl.v3d.Primitive#toPolygons()
+     */
+    @Override
+    public List<Polygon> toPolygons() {
+    	
+    	double phi = (Math.sqrt(5)+1)/2;
+    	
+    	List<Vector3d> points = new ArrayList<>();
+    		points.add(new Vector3d(0,1,phi));
+			points.add(new Vector3d(0,-1,phi));
+			points.add(new Vector3d(phi,0,1));
+			points.add(new Vector3d(1,phi,0));
+			points.add(new Vector3d(-1,phi,0));
+			points.add(new Vector3d(-phi,0,1));
+			points.add(new Vector3d(1,-phi,0));
+			points.add(new Vector3d(phi,0,-1));
+			points.add(new Vector3d(0,1,-phi));
+			points.add(new Vector3d(-phi,0,1));
+			points.add(new Vector3d(-1,-phi,0));
+			points.add(new Vector3d(0,-1,phi));
+    	
+		List<Polygon> polygons = HullUtil.hull(points).scale(1/(Math.sqrt(1+Math.pow(phi, 2)))).getPolygons();
+
+        return polygons;
+    }
+
+    /**
+     * Gets the center.
+     *
+     * @return the center
+     */
+    public Vector3d getCenter() {
+        return center;
+    }
+
+    /**
+     * Sets the center.
+     *
+     * @param center the center to set
+     */
+    public Icosahedron setCenter(Vector3d center) {
+        this.center = center;
+        return this;
+    }
+
+    /**
+     * Gets the radius.
+     *
+     * @return the radius
+     */
+    public double getRadius() {
+        return radius;
+    }
+
+    /**
+     * Sets the radius.
+     *
+     * @param radius the radius to set
+     */
+    public void setRadius(double radius) {
+        this.radius = radius;
+    }
+
+    /* (non-Javadoc)
+     * @see eu.mihosoft.vrl.v3d.Primitive#getProperties()
+     */
+    @Override
+    public PropertyStorage getProperties() {
+        return properties;
+    }
+
+    /**
+     * Defines that this cube will not be centered.
+     * @return this cube
+     */
+    public Icosahedron noCenter() {
+        centered = false;
+        return this;
+    }
+
+}

--- a/src/main/java/eu/mihosoft/vrl/v3d/Icosahedron.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Icosahedron.java
@@ -38,7 +38,7 @@ public class Icosahedron extends Primitive {
     /**
      * Constructor. Creates a new icosahedron with center {@code [0,0,0]} and
      * radius {@code size}.
-     *
+     * This is a platonic solid
      * @param size size
      */
     public Icosahedron(double size) {

--- a/src/main/java/eu/mihosoft/vrl/v3d/Icosahedron.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Icosahedron.java
@@ -76,11 +76,11 @@ public class Icosahedron extends Primitive {
 			points.add(new Vector3d(1,-phi,0));
 			points.add(new Vector3d(phi,0,-1));
 			points.add(new Vector3d(0,1,-phi));
-			points.add(new Vector3d(-phi,0,1));
+			points.add(new Vector3d(-phi,0,-1));
 			points.add(new Vector3d(-1,-phi,0));
-			points.add(new Vector3d(0,-1,phi));
+			points.add(new Vector3d(0,-1,-phi));
     	
-		List<Polygon> polygons = HullUtil.hull(points).scale(1/(Math.sqrt(1+Math.pow(phi, 2)))).getPolygons();
+		List<Polygon> polygons = HullUtil.hull(points).scale(radius/(Math.sqrt(1+Math.pow(phi, 2)))).getPolygons();
 
         return polygons;
     }

--- a/src/main/java/eu/mihosoft/vrl/v3d/Primitive.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Primitive.java
@@ -51,7 +51,7 @@ public abstract class Primitive implements ItoCSG{
      *  Note:  this method computes the polygons each time this method is
      * called. The polygons can be cached inside a {@link CSG} object.
      *
-     * @return al list of polygons that define this primitive
+     * @return a list of polygons that define this primitive
      */
     public abstract List<Polygon> toPolygons();
 

--- a/src/main/java/eu/mihosoft/vrl/v3d/RoundedCube.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/RoundedCube.java
@@ -13,7 +13,7 @@ import eu.mihosoft.vrl.v3d.parametrics.LengthParameter;
 // TODO: Auto-generated Javadoc
 /**
  * The Class RoundedCube.
- *
+ * 
  * @author Michael Hoffer &lt;info@michaelhoffer.de&gt;
  */
 public class RoundedCube extends Primitive {

--- a/src/test/java/eu/mihosoft/vrl/v3d/IcosahedronTest.java
+++ b/src/test/java/eu/mihosoft/vrl/v3d/IcosahedronTest.java
@@ -1,0 +1,31 @@
+package eu.mihosoft.vrl.v3d;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+import eu.mihosoft.vrl.v3d.FileUtil;
+
+
+public class IcosahedronTest {
+
+	@Test
+	public void test() throws IOException {
+		double radius = 10;
+		
+		CSG icosahedron = new Icosahedron(radius).toCSG();
+		CSG box = new Cube(3*radius).toCSG().difference(new Cube(1.7013016167*radius).toCSG());
+		CSG insphere = new Sphere(0.794654472292*radius).toCSG();
+		
+		assertTrue(icosahedron.intersect(box).getPolygons().size() == 0);
+		assertTrue(insphere.difference(icosahedron).getPolygons().size() == 0);
+		
+		FileUtil.write(Paths.get("icosahedron.stl"),
+			icosahedron.toStlString());
+	}
+
+}


### PR DESCRIPTION
An Icosahedron primitive will allow the user to easily generate a regular icosahedron that they can then use in a low resolution Minkowski transformation. The Icosahedron Test allows us the verify that the Icosahedron primitive is functioning as expected.