### PR TITLE
Added Dodecahedron and Dodecahedron Test

### DIFF
--- a/src/main/java/eu/mihosoft/vrl/v3d/Dodecahedron.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Dodecahedron.java
@@ -1,0 +1,150 @@
+/**
+ * Dodecahedron.java
+ */
+package eu.mihosoft.vrl.v3d;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.mihosoft.vrl.v3d.ext.quickhull3d.HullUtil;
+import eu.mihosoft.vrl.v3d.parametrics.LengthParameter;
+import eu.mihosoft.vrl.v3d.parametrics.Parameter;
+
+public class Dodecahedron extends Primitive {
+
+    /**
+     * Center of this dodecahedron.
+     */
+    private Vector3d center;
+    /**
+     * Dodecahedron circumscribed radius.
+     */
+    private double radius;
+
+    /** The centered. */
+    private boolean centered = true;
+
+    /** The properties. */
+    private final PropertyStorage properties = new PropertyStorage();
+    /**
+     * Constructor. Creates a new dodecahedron with center {@code [0,0,0]} and
+     * dimensions {@code [1,1,1]}.
+     */
+    public Dodecahedron() {
+        center = new Vector3d(0, 0, 0);
+        radius = 1;
+    }
+
+    /**
+     * Constructor. Creates a new dodecahedron with center {@code [0,0,0]} and
+     * radius {@code size}.
+     * 
+     * @param size size
+     */
+    public Dodecahedron(double size) {
+        center = new Vector3d(0, 0, 0);
+        radius = size;
+    }
+
+    /**
+     * Constructor. Creates a new dodecahedron with the specified center and
+     * radius.
+     *
+     * @param center center of the dodecahedron
+     * @param circumradius of the dodecahedron
+     */
+    public Dodecahedron(Vector3d center, double size) {
+        this.center = center;
+        this.radius = size;
+    }
+    
+    /* (non-Javadoc)
+     * @see eu.mihosoft.vrl.v3d.Primitive#toPolygons()
+     */
+    @Override
+    public List<Polygon> toPolygons() {
+    	
+    	double phi = (Math.sqrt(5)+1)/2;
+    	
+    	List<Vector3d> points = new ArrayList<>();
+	    	points.add(new Vector3d(-1,-1,-1));
+	    	points.add(new Vector3d(-1,-1,+1));
+	    	points.add(new Vector3d(-1,+1,-1));
+	    	points.add(new Vector3d(-1,+1,+1));
+	    	points.add(new Vector3d(+1,-1,-1));
+	    	points.add(new Vector3d(+1,-1,+1));
+	    	points.add(new Vector3d(+1,+1,-1));
+	    	points.add(new Vector3d(+1,+1,+1));
+    		points.add(new Vector3d(0,1/phi,phi));
+			points.add(new Vector3d(0,-1/phi,phi));
+			points.add(new Vector3d(phi,0,1/phi));
+			points.add(new Vector3d(1/phi,phi,0));
+			points.add(new Vector3d(-1/phi,phi,0));
+			points.add(new Vector3d(-phi,0,1/phi));
+			points.add(new Vector3d(1/phi,-phi,0));
+			points.add(new Vector3d(phi,0,-1/phi));
+			points.add(new Vector3d(0,1/phi,-phi));
+			points.add(new Vector3d(-phi,0,-1/phi));
+			points.add(new Vector3d(-1/phi,-phi,0));
+			points.add(new Vector3d(0,-1/phi,-phi));
+    	
+		List<Polygon> polygons = HullUtil.hull(points).scale(radius*(phi-1)).getPolygons();
+
+        return polygons;
+    }
+
+    /**
+     * Gets the center.
+     *
+     * @return the center
+     */
+    public Vector3d getCenter() {
+        return center;
+    }
+
+    /**
+     * Sets the center.
+     *
+     * @param center the center to set
+     */
+    public Dodecahedron setCenter(Vector3d center) {
+        this.center = center;
+        return this;
+    }
+
+    /**
+     * Gets the radius.
+     *
+     * @return the radius
+     */
+    public double getRadius() {
+        return radius;
+    }
+
+    /**
+     * Sets the radius.
+     *
+     * @param radius the radius to set
+     */
+    public void setRadius(double radius) {
+        this.radius = radius;
+    }
+
+    /* (non-Javadoc)
+     * @see eu.mihosoft.vrl.v3d.Primitive#getProperties()
+     */
+    @Override
+    public PropertyStorage getProperties() {
+        return properties;
+    }
+
+    /**
+     * Defines that this dodecahedron will not be centered.
+     * @return this dodecahedron
+     */
+    public Dodecahedron noCenter() {
+        centered = false;
+        return this;
+    }
+
+}

--- a/src/main/java/eu/mihosoft/vrl/v3d/Icosahedron.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Icosahedron.java
@@ -38,7 +38,7 @@ public class Icosahedron extends Primitive {
     /**
      * Constructor. Creates a new icosahedron with center {@code [0,0,0]} and
      * radius {@code size}.
-     * This is a platonic solid
+     * 
      * @param size size
      */
     public Icosahedron(double size) {
@@ -131,8 +131,8 @@ public class Icosahedron extends Primitive {
     }
 
     /**
-     * Defines that this cube will not be centered.
-     * @return this cube
+     * Defines that this icosahedron will not be centered.
+     * @return this icosahedron
      */
     public Icosahedron noCenter() {
         centered = false;

--- a/src/test/java/eu/mihosoft/vrl/v3d/DodecahedronTest.java
+++ b/src/test/java/eu/mihosoft/vrl/v3d/DodecahedronTest.java
@@ -1,0 +1,31 @@
+package eu.mihosoft.vrl.v3d;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+import eu.mihosoft.vrl.v3d.FileUtil;
+
+
+public class DodecahedronTest {
+
+	@Test
+	public void test() throws IOException {
+		double radius = 10;
+		
+		CSG dodecahedron = new Dodecahedron(radius).toCSG();
+		CSG box = new Cube(3*radius).toCSG().difference(new Cube(2*radius).toCSG());
+		CSG insphere = new Sphere(0.794654472292*radius).toCSG();
+		
+		assertTrue(dodecahedron.intersect(box).getPolygons().size() == 0);
+		assertTrue(insphere.difference(dodecahedron).getPolygons().size() == 0);
+		
+		FileUtil.write(Paths.get("dodecahedron.stl"),
+			dodecahedron.toStlString());
+	}
+
+}


### PR DESCRIPTION
A Dodecahedron primitive will allow the user to easily create a dodecahedron that they can then use in a low resolution Minkowski transformation. The Dodecahedron Test allows us to make sure that the Dodecahedron primitive is working as expected.