### PR TITLE
Delete invalid symlink

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-/home/hephaestus/gradle.properties


### PR DESCRIPTION
You should not commit symlinks in git repos. If you want a `gradle.properties` in the build, then put the actual file in the repo.