### PR TITLE
Make stacktrace creation optional in CSG

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-/home/hephaestus/gradle.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+/home/hephaestus/gradle.properties

--- a/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
@@ -128,10 +128,6 @@ public class CSG implements IuserAPI{
 	/** The manipulator. */
 	private Affine manipulator;
 	private Bounds bounds;
-	/**
-	 * This is the trace for where this csg was created
-	 */
-	private final Exception creationEventStackTrace = new Exception();
 	public static final int INDEX_OF_PARAMETRIC_DEFAULT = 0;
 	public static final int INDEX_OF_PARAMETRIC_LOWER = 1;
 	public static final int INDEX_OF_PARAMETRIC_UPPER = 2;
@@ -155,9 +151,18 @@ public class CSG implements IuserAPI{
 	 * Instantiates a new csg.
 	 */
 	public CSG() {
-		storage = new PropertyStorage();
-		addStackTrace(creationEventStackTrace);
+		this(true);
 	}
+
+	public CSG(boolean makeException) {
+		storage = new PropertyStorage();
+
+		if (makeException) {
+			// This is the trace for where this csg was created
+			addStackTrace(new Exception());
+		}
+	}
+
 	public CSG prepForManufacturing() {
 		if (getManufacturing() == null)
 			return this;
@@ -2253,7 +2258,7 @@ public class CSG implements IuserAPI{
 	}
 
 	/**
-	 * @param exportFormats the exportFormat to add
+	 * @param exportFormat the exportFormat to add
 	 */
 	public void addExportFormat(String exportFormat) {
 		if(this.exportFormats==null)


### PR DESCRIPTION
Creating a stacktrace in every CSG is expensive (I profiled my CSG slicer and creating stracktraces is the vast majority of the CPU time). This PR adds another constructor that makes stacktrace creation optional. The default behavior is preserved for the no-arg constructor.

Not sure why GitHub thinks this is a massive change. If you select "hide whitespace" in the PR review tool, the change looks sane.