### PR TITLE
Ignore out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /CSGdatabase.json
 /*.stl
 /*.svg
+out
+


### PR DESCRIPTION
The `out` directory should be ignored.