### PR TITLE
Added ability for CSG's to contain Transformable objects

### DIFF
--- a/src/main/java/eu/mihosoft/vrl/v3d/MutableTransformable.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/MutableTransformable.java
@@ -1,0 +1,11 @@
+package eu.mihosoft.vrl.v3d;
+
+public interface MutableTransformable extends Transformable {
+    /**
+     * Transforms the object in place.
+     *
+     * @param transform the transform
+     * @return this
+     */
+    MutableTransformable transform(Transform transform);
+}

--- a/src/main/java/eu/mihosoft/vrl/v3d/Polygon.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Polygon.java
@@ -48,7 +48,7 @@ import eu.mihosoft.vrl.v3d.ext.org.poly2tri.PolygonUtil;
  * polygon. This can be used to define per-polygon properties (such as surface
  * color).
  */
-public final class Polygon {
+public final class Polygon implements MutableTransformable {
 
     /** Polygon vertices. */
     public final List<Vertex> vertices;
@@ -274,6 +274,7 @@ public final class Polygon {
      *
      * @return this polygon
      */
+    @Override
     public Polygon transform(Transform transform) {
 
         this.vertices.stream().forEach(
@@ -308,6 +309,7 @@ public final class Polygon {
      * @param transform the transformation to apply
      * @return a transformed copy of this polygon
      */
+    @Override
     public Polygon transformed(Transform transform) {
         return clone().transform(transform);
     }

--- a/src/main/java/eu/mihosoft/vrl/v3d/Transformable.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Transformable.java
@@ -1,0 +1,10 @@
+package eu.mihosoft.vrl.v3d;
+
+public interface Transformable {
+    /**
+     * @param transform the transform
+     * @return a transformed version of this object
+     */
+    Transformable transformed(Transform transform);
+    Transformable clone();
+}

--- a/src/main/java/eu/mihosoft/vrl/v3d/Vector3d.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Vector3d.java
@@ -45,8 +45,8 @@ import java.util.Random;
  *
  * @author Michael Hoffer &lt;info@michaelhoffer.de&gt;
  */
-public class Vector3d extends javax.vecmath.Vector3d{
-
+public class Vector3d extends javax.vecmath.Vector3d
+        implements MutableTransformable {
 
     /**
 	 * 
@@ -327,6 +327,7 @@ public class Vector3d extends javax.vecmath.Vector3d{
      *
      * @return this vector
      */
+    @Override
     public Vector3d transform(Transform transform) {
         return transform.transform(this);
     }
@@ -340,6 +341,7 @@ public class Vector3d extends javax.vecmath.Vector3d{
      *
      * @return a transformed copy of this vector
      */
+    @Override
     public Vector3d transformed(Transform transform) {
         return clone().transform(transform);
     }

--- a/src/main/java/eu/mihosoft/vrl/v3d/Vertex.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Vertex.java
@@ -41,7 +41,7 @@ import java.util.Objects;
  * primitives like {@link Cube} can return a smooth vertex normal, but
  * {@link #normal} is not used anywhere else.
  */
-public class Vertex {
+public class Vertex implements MutableTransformable {
 
     /**
      * Vertex position.
@@ -155,6 +155,7 @@ public class Vertex {
      * @param transform the transform to apply
      * @return this vertex
      */
+    @Override
     public Vertex transform(Transform transform) {
         pos = pos.transform(transform, weight);
         return this;
@@ -166,6 +167,7 @@ public class Vertex {
      * @param transform the transform to apply
      * @return a copy of this transform
      */
+    @Override
     public Vertex transformed(Transform transform) {
         return clone().transform(transform);
     }

--- a/src/test/java/eu/mihosoft/vrl/v3d/SubTransformableTest.java
+++ b/src/test/java/eu/mihosoft/vrl/v3d/SubTransformableTest.java
@@ -1,0 +1,71 @@
+package eu.mihosoft.vrl.v3d;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class SubTransformableTest {
+    @Test
+    public void vectorsMovedTest() {
+        CSG cube = new Cube(4.0).toCSG();
+        Map<String, Transformable> st = cube.getSubTransformable();
+
+        st.put("pointToConnect", new Vector3d(-2.0, -1.0, -2.0));
+        st.put("top", Vector3d.z(4));
+
+        cube.movex(3);
+        cube.movez(2);
+
+        assertEquals(st.get("pointToConnect"), new Vector3d(1.0, -1.0, 0.0));
+        assertEquals(st.get("top"), new Vector3d(3.0, 0.0, 6.0));
+    }
+
+    @Test
+    public void csgUnionTest() {
+        CSG hat = getHatWithSubTransformable();
+        Map<String, Transformable> st = hat.getSubTransformable();
+
+        CSG union = hat.union(new Cube(0.5).toCSG());
+        assertTrue(union.getSubTransformable().containsKey("s"));
+        assertTrue(union.getSubTransformable().containsKey("v"));
+        assertNotSame(union.getSubTransformable(), st);
+
+        // reverse
+        union = new Cube(0.5).toCSG().union(hat);
+        assertTrue(union.getSubTransformable().containsKey("s"));
+        assertTrue(union.getSubTransformable().containsKey("v"));
+        assertNotSame(union.getSubTransformable(), st);
+    }
+
+    private CSG getHatWithSubTransformable() {
+        CSG hat = new Cylinder(3.0, 2.2).toCSG();
+        CSG ornament = new Dodecahedron(1.1).toCSG();
+        hat.getSubTransformable().put("s", ornament);
+        hat.getSubTransformable().put("v", Vector3d.y(-3.24));
+        return hat;
+    }
+
+    @Test
+    public void cloneTest() {
+        CSG hat = getHatWithSubTransformable();
+        Map<String, Transformable> st = hat.getSubTransformable();
+
+        Map<String, Transformable> stOfClone = hat.clone().getSubTransformable();
+
+        assertNotSame(st.get("s"), stOfClone.get("s"));
+        assertEquals(st.get("v"), stOfClone.get("v"));
+        assertNotSame(st.get("v"), stOfClone.get("v"));
+    }
+
+    @Test
+    public void disabledInPlaceTransformationsTest() {
+        CSG hat = getHatWithSubTransformable();
+        hat.setSubTransformableMutationEnabled(false);
+        Map<String, Transformable> st = hat.getSubTransformable();
+        Map<String, Transformable> stOfTransformed = hat.movey(9).getSubTransformable();
+
+        assertNotSame(st.get("v"), stOfTransformed.get("v"));
+    }
+}

--- a/src/test/java/eu/mihosoft/vrl/v3d/SubTransformableTest.java
+++ b/src/test/java/eu/mihosoft/vrl/v3d/SubTransformableTest.java
@@ -28,14 +28,14 @@ public class SubTransformableTest {
         Map<String, Transformable> st = hat.getSubTransformable();
 
         CSG union = hat.union(new Cube(0.5).toCSG());
-        assertTrue(union.getSubTransformable().containsKey("s"));
-        assertTrue(union.getSubTransformable().containsKey("v"));
+        assertEquals(st.get("s"), union.getSubTransformable().get("s"));
+        assertEquals(st.get("v"), union.getSubTransformable().get("v"));
         assertNotSame(union.getSubTransformable(), st);
 
         // reverse
         union = new Cube(0.5).toCSG().union(hat);
-        assertTrue(union.getSubTransformable().containsKey("s"));
-        assertTrue(union.getSubTransformable().containsKey("v"));
+        assertEquals(st.get("s"), union.getSubTransformable().get("s"));
+        assertEquals(st.get("v"), union.getSubTransformable().get("v"));
         assertNotSame(union.getSubTransformable(), st);
     }
 


### PR DESCRIPTION
By default, transformable objects are `Vector3d`, `Vertex`, `Polygon` and `CSG` itself, but users can create their own by implementing `Transformable` or  `MutableTransformable`. When the containing `CSG` is transformed (e.g. `movex` is called), the same `Transform` is applied to all the values in the `subTransformable` map.

How this is done, depends on whether the object is `Transformable` or `MutableTransformable` (extends `Transformable`). In the former case, a new transformed version is stored in the map. In the latter case, the object is directly transformed and stays in the map. 

If `subTransformableMutationEnabled` is set to `false`, the former case is always true. (`transformed` is used on every value, not `transform`.)

By default `subTransformable` is null to avoid increasing memory usage for any case in which there's no need for this feature.

**Edit:** Closes #20.