### PR TITLE
Use Vector3f instead of com.sun Vec3f.

### DIFF
--- a/src/main/java/eu/mihosoft/vrl/v3d/ext/openjfx/importers/SmoothingGroups.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/ext/openjfx/importers/SmoothingGroups.java
@@ -31,6 +31,7 @@
  */
 package eu.mihosoft.vrl.v3d.ext.openjfx.importers;
 
+import eu.mihosoft.vrl.v3d.Vector3d;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -40,8 +41,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import com.sun.javafx.geom.Vec3f;
 import javafx.scene.shape.TriangleMesh;
+import javax.vecmath.Vector3f;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -179,8 +180,8 @@ public class SmoothingGroups {
      * @param index the index
      * @return the normal
      */
-    Vec3f getNormal(int index) {
-        return new Vec3f(normals[index * 3], normals[index * 3 + 1], normals[index * 3 + 2]);
+    Vector3f getNormal(int index) {
+        return new Vector3f(normals[index * 3], normals[index * 3 + 1], normals[index * 3 + 2]);
     }
     
     /** The Constant normalAngle. */
@@ -193,15 +194,15 @@ public class SmoothingGroups {
      * @param n2 the n2
      * @return true, if is normals equal
      */
-    private static boolean isNormalsEqual(Vec3f n1, Vec3f n2) {
+    private static boolean isNormalsEqual(Vector3f n1, Vector3f n2) {
         if (n1.x == 1.0e20f || n1.y == 1.0e20f || n1.z == 1.0e20f
                 || n2.x == 1.0e20f || n2.y == 1.0e20f || n2.z == 1.0e20f) {
             //System.out.println("unlocked normal found, skipping");
             return false;
         }
-        Vec3f myN1 = new Vec3f(n1);
+        Vector3f myN1 = new Vector3f(n1);
         myN1.normalize();
-        Vec3f myN2 = new Vec3f(n2);
+        Vector3f myN2 = new Vector3f(n2);
         myN2.normalize();
         return myN1.dot(myN2) >= normalAngle;
     }

--- a/src/main/java/eu/mihosoft/vrl/v3d/svg/SVGExporter.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/svg/SVGExporter.java
@@ -7,14 +7,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import com.sun.javafx.geom.transform.Affine3D;
 import eu.mihosoft.vrl.v3d.CSG;
 import eu.mihosoft.vrl.v3d.Polygon;
 import eu.mihosoft.vrl.v3d.Slice;
 import eu.mihosoft.vrl.v3d.Transform;
 import eu.mihosoft.vrl.v3d.Vector3d;
 import eu.mihosoft.vrl.v3d.Vertex;
-import javafx.scene.paint.Color;
 
 @SuppressWarnings("restriction")
 public class SVGExporter {


### PR DESCRIPTION
### Description

This PR removes uses of `com.sun.javafx.geom.Vec3f` and replaces them with `javax.vecmath.Vector3f`. These two classes implement the same functionality in the same way, so there should not be a problem here.

### Motivation

I am working on getting releases built for the new kernel and this PR fixes some compiler errors I am getting.