### PR TITLE
Update the color of all polygons when setting the color to a CSG

### DIFF
--- a/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
@@ -207,9 +207,12 @@ public class CSG implements IuserAPI {
 	 */
 	public CSG setColor(Color color) {
 		this.color = color;
-        getStorage().set(PropertyStorage.PROPERTY_MATERIAL_COLOR, color.getRed()
-                + " " + color.getGreen()
-                + " " + color.getBlue());
+		String colorAsString = color.getRed()
+				+ " " + color.getGreen()
+				+ " " + color.getBlue();
+
+		getStorage().set(PropertyStorage.PROPERTY_MATERIAL_COLOR, colorAsString);
+		polygons.forEach(p -> p.getStorage().set(PropertyStorage.PROPERTY_MATERIAL_COLOR, colorAsString));
 
 		if (current != null) {
 			PhongMaterial m = new PhongMaterial(getColor());
@@ -240,7 +243,6 @@ public class CSG implements IuserAPI {
 	public CSG setManipulator(Affine manipulator) {
 		if (manipulator == null)
 			return this;
-		Affine old = manipulator;
 		this.manipulator = manipulator;
 		if (current != null) {
 			current.getTransforms().clear();
@@ -775,7 +777,6 @@ public class CSG implements IuserAPI {
 		case POLYGON_BOUND:
 			return _unionPolygonBoundsOpt(csg).historySync(this).historySync(csg);
 		default:
-			// return _unionIntersectOpt(csg);
 			return _unionNoOpt(csg).historySync(this).historySync(csg);
 		}
 	}
@@ -2207,7 +2208,7 @@ public class CSG implements IuserAPI {
 					this.setParameter(vals, dyingCSG.getMapOfparametrics().get(param));
 			}
 		}
-		this.setColor(dyingCSG.getColor());
+		color = dyingCSG.getColor();
 		if (getName().length() == 0)
 			setName(dyingCSG.getName());
 		return this;
@@ -2831,10 +2832,6 @@ public class CSG implements IuserAPI {
 		return false;
 	}
 
-//	public CSG setIsGroupResult(boolean res) {
-//		getStorage().set("GroupResult", res);
-//		return this;
-//	}
 	public CSG addIsGroupResult(String res) {
 		if( !getStorage().getValue("GroupResult").isPresent()) {
 			getStorage().set("GroupResult", new HashSet<String>());
@@ -3110,8 +3107,6 @@ public class CSG implements IuserAPI {
 	    return tessellateXY(incoming, xSteps, ySteps, xGrid, yGrid, 0, 0, 0, 0);
 	}
 
-
-
 	/**
 	 * 
 	 * @param incoming Hexagon (with flats such that Y total is flat to flat distance)
@@ -3125,6 +3120,7 @@ public class CSG implements IuserAPI {
 		double x =(((y/Math.sqrt(3))))*(3/2);
 		return tessellateXY(incoming,xSteps,ySteps,x,y,0,0,0,y/2);
 	}
+
 	/**
 	 * 
 	 * @param incoming Hexagon (with flats such that Y total is flat to flat distance)

--- a/src/test/java/eu/mihosoft/vrl/v3d/CSGTest.java
+++ b/src/test/java/eu/mihosoft/vrl/v3d/CSGTest.java
@@ -22,10 +22,9 @@ public class CSGTest {
                 .setColor(Color.BLUE);
         assertEquals(Color.BLUE, cube.getColor());
 
-        String colorAsString = Color.BLUE.getRed() + " " + Color.BLUE.getGreen() + " " + Color.BLUE.getBlue();
         cube.getPolygons().forEach(polygon -> {
             String polygonColorAsString = getColorAsString(polygon);
-            assertEquals("Expected the polygon to get the same color as the CSG", colorAsString, polygonColorAsString);
+            assertEquals("Expected the polygon to get the same color as the CSG", BLUE_COLOR_AS_STRING, polygonColorAsString);
         });
     }
 
@@ -49,6 +48,39 @@ public class CSGTest {
             } else {
                 assertEquals("Expected the right cube polygons to be red", RED_COLOR_AS_STRING, polygonColorAsString);
             }
+        });
+    }
+
+    @Test
+    public void setColor_OnCSGShouldChangeColorsOfAllPolygons() {
+        CSG cube = new Cube(10).toCSG()
+                .setColor(Color.BLUE);
+        assertEquals(Color.BLUE, cube.getColor());
+
+        cube.setColor(Color.RED);
+
+        cube.getPolygons().forEach(polygon -> {
+            String polygonColorAsString = getColorAsString(polygon);
+            assertEquals("Expected the cube polygons to be another color", RED_COLOR_AS_STRING, polygonColorAsString);
+        });
+    }
+
+    @Test
+    public void setColor_OnUnionedCSGShouldChangeColorsOfAllPolygons() {
+        CSG cube1 = new Cube(10).toCSG()
+                .setColor(Color.BLUE);
+
+        CSG cube2 = new Cube(10).toCSG()
+                .setColor(Color.RED)
+                .transformed(new Transform().translate(10, 0, 0));
+
+        CSG union = cube1.union(cube2);
+        assertEquals("Expected the new object to inherit the color from the latest unioned object", Color.RED, union.getColor());
+
+        union.setColor(Color.BLUE);
+        union.getPolygons().forEach(polygon -> {
+            String polygonColorAsString = getColorAsString(polygon);
+            assertEquals("Expected the cube polygons to be another color", BLUE_COLOR_AS_STRING, polygonColorAsString);
         });
     }
 }


### PR DESCRIPTION
After an geometric operation the polygons in the CSG will retain its color information. This change will make it so that if a new color is set on the CSG it will overwrite the colors on all polygons.

Relates to issue #53