### PR TITLE
Copy the color of the polygons on difference operations

### DIFF
--- a/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/CSG.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -708,19 +709,11 @@ public class CSG implements IuserAPI {
 	@Override
 	public CSG clone() {
 		CSG csg = new CSG();
-
 		csg.setOptType(this.getOptType());
-
-		Stream<Polygon> polygonStream;
-
-//		if (getPolygons().size() > 200) {
-//			polygonStream = getPolygons().parallelStream();
-//		} else {
-//			polygonStream =getPolygons().stream();
-//		}
-		polygonStream=getPolygons().stream();
-		csg.setPolygons(polygonStream.map((Polygon p) -> p!=null?p.clone():null).filter(p-> p!=null).collect(Collectors.toList()));
-
+		csg.setPolygons(polygons.stream()
+				.filter(Objects::nonNull)
+				.map(Polygon::clone)
+				.collect(Collectors.toList()));
 		return csg.historySync(this);
 	}
 
@@ -1213,15 +1206,13 @@ public class CSG implements IuserAPI {
 	 * @return the csg
 	 */
 	private CSG _differenceCSGBoundsOpt(CSG csg) {
-		CSG b = csg;
-
-		CSG a1 = this._differenceNoOpt(csg.getBounds().toCSG());
-		CSG a2 = this.intersect(csg.getBounds().toCSG());
-		CSG BACK = a2._differenceNoOpt(b)._unionIntersectOpt(a1).optimization(getOptType());
+		CSG a1 = this._differenceNoOpt(csg.getBounds().toCSG().setColor(csg.getColor()));
+		CSG a2 = this.intersect(csg.getBounds().toCSG().setColor(csg.getColor()));
+		CSG result = a2._differenceNoOpt(csg)._unionIntersectOpt(a1).optimization(getOptType());
 		if (getName().length() != 0 && csg.getName().length() != 0) {
-			BACK.setName( name);
+			result.setName( name);
 		}
-		return BACK;
+		return result;
 	}
 
 	/**
@@ -1937,7 +1928,7 @@ public class CSG implements IuserAPI {
 	 *
 	 * @return the optType
 	 */
-	private OptType getOptType() {
+	protected OptType getOptType() {
 		return optType != null ? optType : defaultOptType;
 	}
 
@@ -2208,7 +2199,6 @@ public class CSG implements IuserAPI {
 					this.setParameter(vals, dyingCSG.getMapOfparametrics().get(param));
 			}
 		}
-		//this.setColor(dyingCSG.getColor());
 		if (getName().length() == 0)
 			setName(dyingCSG.getName());
 		return this;

--- a/src/main/java/eu/mihosoft/vrl/v3d/Plane.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Plane.java
@@ -37,7 +37,6 @@ package eu.mihosoft.vrl.v3d;
 import java.util.ArrayList;
 import java.util.List;
 
-// TODO: Auto-generated Javadoc
 /**
  * Represents a plane in 3D space.
  *
@@ -170,7 +169,6 @@ public class Plane {
         for (int i = 0; i < polygon.vertices.size(); i++) {
             double t = this.normal.dot(polygon.vertices.get(i).pos) - this.dist; 
             int type = (t < negEpsilon) ? BACK : (t > posEpsilon) ? FRONT : COPLANAR;
-            //polygonType |= type;
             if(type==BACK)
             	somePointsInBack=true;
             if(type==FRONT)
@@ -184,23 +182,18 @@ public class Plane {
         }else if(somePointsInfront)
         	polygonType=FRONT;
 
-        //System.out.println("> switching");
         // Put the polygon in the correct list, splitting it when necessary.
         switch (polygonType) {
             case COPLANAR:
-                //System.out.println(" -> coplanar");
                 (this.normal.dot(polygon.plane.normal) > 0 ? coplanarFront : coplanarBack).add(polygon);
                 break;
             case FRONT:
-                //System.out.println(" -> front");
                 front.add(polygon);
                 break;
             case BACK:
-                //System.out.println(" -> back");
                 back.add(polygon);
                 break;
             case SPANNING:
-                //System.out.println(" -> spanning");
                 List<Vertex> f = new ArrayList<>();
                 List<Vertex> b = new ArrayList<>();
                 for (int i = 0; i < polygon.vertices.size(); i++) {
@@ -224,13 +217,13 @@ public class Plane {
                     }
                 }
                 if (f.size() >= 3) {
-                    front.add(new Polygon(f, polygon.getStorage()));
-                }else {
+                    front.add(new Polygon(f, polygon.getStorage()).setColor(polygon.getColor()));
+                } else {
                 	System.out.println("Front Clip Fault!");
                 }
                 if (b.size() >= 3) {
-                    back.add(new Polygon(b, polygon.getStorage()));
-                }else {
+                    back.add(new Polygon(b, polygon.getStorage()).setColor(polygon.getColor()));
+                } else {
                 	System.out.println("Back Clip Fault!");
                 }
                 break;

--- a/src/test/java/eu/mihosoft/vrl/v3d/CSGTest.java
+++ b/src/test/java/eu/mihosoft/vrl/v3d/CSGTest.java
@@ -2,6 +2,7 @@ package eu.mihosoft.vrl.v3d;
 
 import javafx.scene.paint.Color;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import org.junit.Test;
 
 public class CSGTest {
@@ -85,11 +86,80 @@ public class CSGTest {
                 .transformed(new Transform().translate(10, 0, 0));
 
         CSG union = cube1.union(cube2);
-        assertEquals("Expected the new object to inherit the color from the latest unioned object", CSG.getDefaultColor(), union.getColor());
+        assertEquals("Expected the new object to get the default color", CSG.getDefaultColor(), union.getColor());
 
         union.setColor(Color.BLUE);
         union.getPolygons().forEach(polygon -> {
             assertEquals("Expected the cube polygons to be another color", Color.BLUE, polygon.getColor());
+        });
+    }
+
+    @Test
+    public void setColor_OnDifferenceWithOptTypeBoundsShouldChangeColorsOfIntersectingPolygons() {
+        CSG cube1 = new Cube(10).toCSG()
+                .move(0, 0, 0)
+                .setColor(Color.BLUE);
+
+        CSG cube2 = new Cube(10).toCSG()
+                .move(9, 0, 0)
+                .setColor(Color.RED);
+
+        assertEquals(CSG.OptType.CSG_BOUND, cube1.getOptType());
+
+        CSG difference = cube1.difference(cube2);
+        assertEquals("Unexpected number of faces", 6, difference.getPolygons().size());
+        difference.getPolygons().forEach(polygon -> {
+            Vector3d center = polygon.getBounds().getCenter();
+            if (center.equals(Vector3d.xyz(-5, 0, 0))) {
+                assertEquals("Expected the left face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(-0.5, -5, 0))) {
+                assertEquals("Expected the front face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(-0.5, 5, 0))) {
+                assertEquals("Expected the back face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(-0.5, 0, -5))) {
+                assertEquals("Expected the bottom face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(-0.5, 0, 5))) {
+                assertEquals("Expected the top face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(4, 0, 0))) {
+                assertEquals("Expected the right face to have another color", Color.RED, polygon.getColor());
+            } else {
+                fail("Unknown face with center" + center);
+            }
+        });
+    }
+
+    @Test
+    public void setColor_OnDifferenceWithOptTypePolygonShouldChangeColorsOfIntersectingPolygons() {
+        CSG cube1 = new Cube(10).toCSG()
+                .move(0, 0, 0)
+                .setColor(Color.BLUE)
+                .setOptType(CSG.OptType.POLYGON_BOUND);
+
+        CSG cube2 = new Cube(10).toCSG()
+                .move(9, 0, 0)
+                .setColor(Color.RED);
+
+        assertEquals(CSG.OptType.POLYGON_BOUND, cube1.getOptType());
+
+        CSG difference = cube1.difference(cube2);
+        assertEquals("Unexpected number of faces", 6, difference.getPolygons().size());
+        difference.getPolygons().forEach(polygon -> {
+            Vector3d center = polygon.getBounds().getCenter();
+            if (center.equals(Vector3d.xyz(-5, 0, 0))) {
+                assertEquals("Expected the left face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(-0.5, -5, 0))) {
+                assertEquals("Expected the front face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(-0.5, 5, 0))) {
+                assertEquals("Expected the back face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(-0.5, 0, -5))) {
+                assertEquals("Expected the bottom face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(-0.5, 0, 5))) {
+                assertEquals("Expected the top face to have another color", Color.BLUE, polygon.getColor());
+            } else if (center.equals(Vector3d.xyz(4, 0, 0))) {
+                assertEquals("Expected the right face to have another color", Color.RED, polygon.getColor());
+            } else {
+                fail("Unknown face with center" + center);
+            }
         });
     }
 }


### PR DESCRIPTION
With this change it will use the color of the intersecting shape to be used on the clipped plane of a shape:

```java
CSG cube1 = new Cube(1)
        .toCSG()
        .move(-0.5, 0, 0)
        .setColor(Color.BLUE);

CSG cube2 = new Cube(1).toCSG().move(0.49, 0, 0)
        .setColor(Color.RED);

CSG model = cube1.difference(cube2).scale(0.4);
```

Which will result in this blue cube with one red face:
[Screencast from 2024-08-13 19-27-15.webm](https://github.com/user-attachments/assets/499d4fa7-31c5-49a6-8af5-f0ced6e9b543)



This can now be used in a bit more complex operations:
[Screencast from 2024-08-13 19-32-14.webm](https://github.com/user-attachments/assets/044bb741-b221-4f3f-b690-4c95e08c0d3c)

Adresses the issue #56