### PR TITLE
Reduce ASCII STL export size by removing indentation and removing trailing zeros

### DIFF
--- a/src/main/java/eu/mihosoft/vrl/v3d/Polygon.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Polygon.java
@@ -309,17 +309,16 @@ public final class Polygon implements Serializable {
 			// TODO: improve the triangulation?
 			//
 			// STL requires triangular polygons.
-			// If our polygon has more vertices, create
-			// multiple triangles:
+			// If our polygon has more vertices, create multiple triangles:
 			String firstVertexStl = this.getVertices().get(0).toStlString();
 
-			sb.append("  facet normal ").append(this.getPlane().getNormal().toStlString()).append("\n")
-					.append("    outer loop\n").append("      ").append(firstVertexStl).append("\n").append("      ");
-			this.getVertices().get(1).toStlString(sb).append("\n").append("      ");
-			this.getVertices().get(2).toStlString(sb).append("\n").append("    endloop\n").append("  endfacet\n");
+			sb.append("facet normal ").append(this.getPlane().getNormal().toStlString()).append("\n")
+					.append("outer loop\n").append(firstVertexStl).append("\n");
+			this.getVertices().get(1).toStlString(sb).append("\n");
+			this.getVertices().get(2).toStlString(sb).append("\n").append("endloop\n").append("endfacet\n");
 
 		} else {
-			throw new RuntimeException("Polygon must be a triangle before STL can be made " + getVertices().size());
+			throw new RuntimeException("Polygon must be a triangle before STL can be made, vertices: " + getVertices().size());
 		}
 
 		return sb;
@@ -888,7 +887,6 @@ public final class Polygon implements Serializable {
 	}
 
 	public int size() {
-
 		return getVertices().size();
 	}
 

--- a/src/main/java/eu/mihosoft/vrl/v3d/Vector3d.java
+++ b/src/main/java/eu/mihosoft/vrl/v3d/Vector3d.java
@@ -306,6 +306,27 @@ public class Vector3d extends javax.vecmath.Vector3d {
 		return new Vector3d(this.y * a.z - this.z * a.y, this.z * a.x - this.x * a.z, this.x * a.y - this.y * a.x);
 	}
 
+	// Minimize ASCII STL size by removing trailing zeros
+	private static String stripTrailingZeros(String formatted) {
+		if ((formatted == null) || formatted.isEmpty())
+			return formatted;
+
+		int decPos = formatted.indexOf('.');
+		if (decPos == -1)
+			return formatted; // Nothing to do
+
+		int i = formatted.length() - 1;
+		
+		while ((i > decPos) && (formatted.charAt(i) == '0'))
+			i--;
+
+		// Remove decimal point if needed
+		if (i == decPos)
+			i--;
+
+		return formatted.substring(0, i + 1);
+	}
+
 	/**
 	 * Returns this vector in STL string format.
 	 *
@@ -324,8 +345,9 @@ public class Vector3d extends javax.vecmath.Vector3d {
 	 */
 	public StringBuilder toStlString(StringBuilder sb) {
 		double ep = getEXPORTEPSILON();
-		return sb.append(roundedValue(x, ep)).append(" ").append(roundedValue(y, ep)).append(" ")
-				.append(roundedValue(z, ep));
+		return sb.append(stripTrailingZeros(roundedValue(x, ep))).append(" ")
+				.append(stripTrailingZeros(roundedValue(y, ep))).append(" ")
+				.append(stripTrailingZeros(roundedValue(z, ep)));
 	}
 
 	public Vector3d roundToEpsilon(double ep) {


### PR DESCRIPTION
Reduce ASCII STL export size by removing indentation and removing trailing zeros

Practical size reduction is at least 12%.